### PR TITLE
Fixed a bug making Open Sans font disabled

### DIFF
--- a/static/css/global.css
+++ b/static/css/global.css
@@ -2,7 +2,7 @@
 {
 	margin: 0;
 	padding: 0;
-	font-family: "open sans", arial, default;
+	font-family: "open sans", arial, sans-serif;
 }
 
 #display

--- a/static/css/startPanel.css
+++ b/static/css/startPanel.css
@@ -45,7 +45,7 @@ a
 {
 	font-size: 10vh;
 	text-align: center;
-	font-family: "open sans", arial, default;
+	font-family: "open sans", arial, sans-serif;
 	font-weight: 300;
 	color: white;
 	text-shadow: black 0 0 5px;


### PR DESCRIPTION
The "font-family: default" in the css was making mozilla ignoring the font-family line and disabling the Open Sans font. So I changed all default to sans-serif and it know works !